### PR TITLE
Fix cursor position bug when typing on first input (#14)

### DIFF
--- a/imports/ui/Editor.jsx
+++ b/imports/ui/Editor.jsx
@@ -103,9 +103,15 @@ export const WysiwygEditor = forwardRef(function WysiwygEditor({ initialValue = 
       // Clear history before first real input (so initialization doesn't count)
       if (!historyInitializedRef.current && (e.key.length === 1 || e.key === 'Backspace' || e.key === 'Delete')) {
         historyInitializedRef.current = true;
+        // Save cursor position before resetting content
+        const { from, to } = editor.state.selection;
         // Reset state to clear undo history - setContent with same content clears history
         const currentContent = editor.getHTML();
         editor.commands.setContent(currentContent, false, { preserveWhitespace: 'full' });
+        // Restore cursor position after setContent (use queueMicrotask to ensure it happens after current sync work)
+        queueMicrotask(() => {
+          editor.commands.setTextSelection({ from, to });
+        });
       }
 
       // Handle undo (Ctrl+Z / Cmd+Z) - ensure it triggers properly


### PR DESCRIPTION
## Summary
- Fixes #14: When clicking in the middle of an existing document and typing, characters now appear at the cursor position instead of at the end
- Root cause: `setContent()` was resetting cursor to end when clearing undo history on first user input
- Solution: Save cursor position before `setContent()` and restore it afterward using `queueMicrotask()`

## Changes
- **Editor.jsx**: Save/restore cursor position around `setContent()` call using `editor.state.selection` and `setTextSelection()`
- **makora.spec.ts**: Add E2E test that verifies typing inserts at cursor position

## Test Plan (Red-Green Testing)
✅ **RED Phase**: Test initially failed
- Marker appeared at position 147/160 (at the end of document)
- Test confirmed the bug existed

✅ **GREEN Phase**: After fix, test passes
- Marker now appears at position < 50% of content (near beginning where cursor was)
- Test run 3 times consecutively - all passed

✅ **Regression Testing**: All existing tests pass (21/22)
- 1 pre-existing test failure unrelated to this change (test pollution issue)

## Technical Details
The fix uses `queueMicrotask()` to ensure cursor restoration happens after the browser processes the keystroke. This prevents the cursor position from being overwritten before the character is inserted.

Before:
```javascript
editor.commands.setContent(currentContent, false, { preserveWhitespace: 'full' });
// Cursor now at end, typing inserts at end
```

After:
```javascript
const { from, to } = editor.state.selection;
editor.commands.setContent(currentContent, false, { preserveWhitespace: 'full' });
queueMicrotask(() => {
  editor.commands.setTextSelection({ from, to });
});
// Cursor position preserved, typing inserts at cursor
```